### PR TITLE
Tk configs recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .nopublish
-
+*.sh
 ### Windows ###
 
 thumbs.db

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -34,6 +34,7 @@ import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.stack.ItemMaterialInfo;
 import gregtech.api.util.AssemblyLineManager;
+import gregtech.common.ConfigHolder;
 import gregtech.core.sound.GTSoundEvents;
 
 import net.minecraft.init.SoundEvents;
@@ -493,16 +494,24 @@ public final class RecipeMaps {
                     .onRecipeBuild(recipeBuilder -> {
                         recipeBuilder.invalidateOnBuildAction();
                         if (recipeBuilder.getFluidInputs().isEmpty()) {
-                            recipeBuilder.copy()
-                                    .fluidInputs(Materials.SolderingAlloy.getFluid(Math.max(1,
-                                            (GTValues.L / 2) * recipeBuilder.getSolderMultiplier())))
-                                    .buildAndRegister();
+                            if (!ConfigHolder.otherStuff.removeTinCircuitRecipes) {
+                                recipeBuilder.copy()
+                                        .fluidInputs(Materials.SolderingAlloy.getFluid(Math.max(1,
+                                                (GTValues.L / 2) * recipeBuilder.getSolderMultiplier())))
+                                        .buildAndRegister();
 
-                            // Don't call buildAndRegister as we are mutating the original recipe and already in the
-                            // middle of a buildAndRegister call.
-                            // Adding a second call will result in duplicate recipe generation attempts
-                            recipeBuilder.fluidInputs(Materials.Tin.getFluid(Math.max(1, GTValues.L *
-                                    recipeBuilder.getSolderMultiplier())));
+                                // Don't call buildAndRegister as we are mutating the original recipe and already in the
+                                // middle of a buildAndRegister call.
+                                // Adding a second call will result in duplicate recipe generation attempts
+                                recipeBuilder.fluidInputs(Materials.Tin.getFluid(Math.max(1, GTValues.L *
+                                        recipeBuilder.getSolderMultiplier())));
+
+                            } else {
+                                recipeBuilder
+                                        .fluidInputs(Materials.SolderingAlloy.getFluid(Math.max(1,
+                                                (GTValues.L / 2) * recipeBuilder.getSolderMultiplier())))
+                                        .buildAndRegister();
+                            }
                         }
                     });
 

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -494,7 +494,7 @@ public final class RecipeMaps {
                     .onRecipeBuild(recipeBuilder -> {
                         recipeBuilder.invalidateOnBuildAction();
                         if (recipeBuilder.getFluidInputs().isEmpty()) {
-                            if (!ConfigHolder.otherStuff.removeTinCircuitRecipes) {
+                            if (!ConfigHolder.recipeRemovalConfig.otherStuff.removeTinCircuitRecipes) {
                                 recipeBuilder.copy()
                                         .fluidInputs(Materials.SolderingAlloy.getFluid(Math.max(1,
                                                 (GTValues.L / 2) * recipeBuilder.getSolderMultiplier())))

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -43,15 +43,10 @@ public class ConfigHolder {
     @Config.RequiresMcRestart
     public static WorldGenOptions worldgen = new WorldGenOptions();
 
-    @Config.Comment("Config options for handling ores processing handlers")
-    @Config.Name("Processing handlers")
+    @Config.Comment("Config options for World Generation features")
+    @Config.Name("Worldgen Options")
     @Config.RequiresMcRestart
-    public static ProcessingHandlers processingHandlers = new ProcessingHandlers();
-
-    @Config.Comment("Config options to disable other recipes")
-    @Config.Name("Other stuff")
-    @Config.RequiresMcRestart
-    public static OtherStuff otherStuff = new OtherStuff();
+    public static RecipeRemovalConfig recipeRemovalConfig = new RecipeRemovalConfig();
 
     public static class MachineOptions {
 
@@ -712,6 +707,19 @@ public class ConfigHolder {
         public int energyConsumption = 64;
     }
 
+    public static class RecipeRemovalConfig {
+
+        @Config.Comment("Config options for handling ores processing handlers")
+        @Config.Name("Processing handlers")
+        @Config.RequiresMcRestart
+        public ProcessingHandlers processingHandlers = new ProcessingHandlers();
+
+        @Config.Comment("Config options to disable other recipes")
+        @Config.Name("Other stuff")
+        @Config.RequiresMcRestart
+        public OtherStuff otherStuff = new OtherStuff();
+    }
+
     public static class ProcessingHandlers {
 
         public boolean removeRotorRecipes;
@@ -727,5 +735,11 @@ public class ConfigHolder {
 
         @Config.Comment({ "Remove circuit assembler recipes using liquid tin" })
         public boolean removeTinCircuitRecipes;
+
+        @Config.Comment({ "Remove ulv to uhv casing shaped recipes" })
+        public boolean removeTierCasingRecipes;
+
+        @Config.Comment({ "Remove all electrolysis recipes including auto-generated recipes" })
+        public boolean removeElectrolysisRecipes;
     }
 }

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -43,6 +43,11 @@ public class ConfigHolder {
     @Config.RequiresMcRestart
     public static WorldGenOptions worldgen = new WorldGenOptions();
 
+    @Config.Comment("Config options for handling ores processing handlers")
+    @Config.Name("Processing handlers")
+    @Config.RequiresMcRestart
+    public static ProcessingHandlers processingHandlers = new ProcessingHandlers();
+
     public static class MachineOptions {
 
         @Config.Comment({ "Whether insufficient energy supply should reset Machine recipe progress to zero.",
@@ -700,5 +705,13 @@ public class ConfigHolder {
         @Config.RangeInt(min = 1, max = 512)
         @Config.Comment({ "The EU/t consumption of the NanoSaber.", "Default: 64" })
         public int energyConsumption = 64;
+    }
+
+    public static class ProcessingHandlers {
+
+        public boolean removeRotorRecipes;
+        public boolean removeWireRecipes;
+        public boolean removeFoilRecipes;
+        public boolean removeFineWireRecipes;
     }
 }

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -48,6 +48,11 @@ public class ConfigHolder {
     @Config.RequiresMcRestart
     public static ProcessingHandlers processingHandlers = new ProcessingHandlers();
 
+    @Config.Comment("Config options to disable other recipes")
+    @Config.Name("Other stuff")
+    @Config.RequiresMcRestart
+    public static OtherStuff otherStuff = new OtherStuff();
+
     public static class MachineOptions {
 
         @Config.Comment({ "Whether insufficient energy supply should reset Machine recipe progress to zero.",
@@ -713,5 +718,14 @@ public class ConfigHolder {
         public boolean removeWireRecipes;
         public boolean removeFoilRecipes;
         public boolean removeFineWireRecipes;
+    }
+
+    public static class OtherStuff {
+
+        @Config.Comment({ "Remove motors, pumps etc. recipes" })
+        public boolean removeComponentRecipes;
+
+        @Config.Comment({ "Remove circuit assembler recipes using liquid tin" })
+        public boolean removeTinCircuitRecipes;
     }
 }

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -43,8 +43,8 @@ public class ConfigHolder {
     @Config.RequiresMcRestart
     public static WorldGenOptions worldgen = new WorldGenOptions();
 
-    @Config.Comment("Config options for World Generation features")
-    @Config.Name("Worldgen Options")
+    @Config.Comment("Config options for selectively disable recipes generation")
+    @Config.Name("Recipe removal config")
     @Config.RequiresMcRestart
     public static RecipeRemovalConfig recipeRemovalConfig = new RecipeRemovalConfig();
 
@@ -711,35 +711,51 @@ public class ConfigHolder {
 
         @Config.Comment("Config options for handling ores processing handlers")
         @Config.Name("Processing handlers")
-        @Config.RequiresMcRestart
         public ProcessingHandlers processingHandlers = new ProcessingHandlers();
 
         @Config.Comment("Config options to disable other recipes")
         @Config.Name("Other stuff")
-        @Config.RequiresMcRestart
         public OtherStuff otherStuff = new OtherStuff();
     }
 
     public static class ProcessingHandlers {
 
+        @Config.Name("removeRotorRecipes")
+        @Config.RequiresMcRestart
         public boolean removeRotorRecipes;
+
+        @Config.Name("removeWireRecipes")
+        @Config.RequiresMcRestart
         public boolean removeWireRecipes;
+
+        @Config.Name("removeFoilRecipes")
+        @Config.RequiresMcRestart
         public boolean removeFoilRecipes;
+        @Config.Name("removeFineWireRecipes")
+        @Config.RequiresMcRestart
         public boolean removeFineWireRecipes;
     }
 
     public static class OtherStuff {
 
         @Config.Comment({ "Remove motors, pumps etc. recipes" })
+        @Config.Name("removeComponentRecipes")
+        @Config.RequiresMcRestart
         public boolean removeComponentRecipes;
 
         @Config.Comment({ "Remove circuit assembler recipes using liquid tin" })
+        @Config.Name("removeTinCircuitRecipes")
+        @Config.RequiresMcRestart
         public boolean removeTinCircuitRecipes;
 
         @Config.Comment({ "Remove ulv to uhv casing shaped recipes" })
+        @Config.Name("removeTierCasingRecipes")
+        @Config.RequiresMcRestart
         public boolean removeTierCasingRecipes;
 
         @Config.Comment({ "Remove all electrolysis recipes including auto-generated recipes" })
+        @Config.Name("removeElectrolysisRecipes")
+        @Config.RequiresMcRestart
         public boolean removeElectrolysisRecipes;
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -63,7 +63,9 @@ public class MachineRecipeLoader {
         AssemblyLineLoader.init();
         FusionLoader.init();
         AssemblerRecipeLoader.init();
-        ComponentRecipes.register();
+        if (!ConfigHolder.otherStuff.removeComponentRecipes) {
+            ComponentRecipes.register();
+        }
         MiscRecipeLoader.init();
         BatteryRecipes.init();
         CircuitRecipes.init();

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -63,7 +63,7 @@ public class MachineRecipeLoader {
         AssemblyLineLoader.init();
         FusionLoader.init();
         AssemblerRecipeLoader.init();
-        if (!ConfigHolder.otherStuff.removeComponentRecipes) {
+        if (!ConfigHolder.recipeRemovalConfig.otherStuff.removeComponentRecipes) {
             ComponentRecipes.register();
         }
         MiscRecipeLoader.init();

--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityLoader.java
@@ -46,26 +46,34 @@ import static gregtech.loaders.recipe.CraftingComponent.*;
 public class MetaTileEntityLoader {
 
     public static void init() {
-        ModHandler.addShapedRecipe(true, "casing_ulv", MetaBlocks.MACHINE_CASING.getItemVariant(ULV), "PPP", "PwP",
-                "PPP", 'P', new UnificationEntry(OrePrefix.plate, Materials.WroughtIron));
-        ModHandler.addShapedRecipe(true, "casing_lv", MetaBlocks.MACHINE_CASING.getItemVariant(LV), "PPP", "PwP", "PPP",
-                'P', new UnificationEntry(OrePrefix.plate, Materials.Steel));
-        ModHandler.addShapedRecipe(true, "casing_mv", MetaBlocks.MACHINE_CASING.getItemVariant(MV), "PPP", "PwP", "PPP",
-                'P', new UnificationEntry(OrePrefix.plate, Materials.Aluminium));
-        ModHandler.addShapedRecipe(true, "casing_hv", MetaBlocks.MACHINE_CASING.getItemVariant(HV), "PPP", "PwP", "PPP",
-                'P', new UnificationEntry(OrePrefix.plate, Materials.StainlessSteel));
-        ModHandler.addShapedRecipe(true, "casing_ev", MetaBlocks.MACHINE_CASING.getItemVariant(EV), "PPP", "PwP", "PPP",
-                'P', new UnificationEntry(OrePrefix.plate, Materials.Titanium));
-        ModHandler.addShapedRecipe(true, "casing_iv", MetaBlocks.MACHINE_CASING.getItemVariant(IV), "PPP", "PwP", "PPP",
-                'P', new UnificationEntry(OrePrefix.plate, Materials.TungstenSteel));
-        ModHandler.addShapedRecipe(true, "casing_luv", MetaBlocks.MACHINE_CASING.getItemVariant(LuV), "PPP", "PwP",
-                "PPP", 'P', new UnificationEntry(OrePrefix.plate, Materials.RhodiumPlatedPalladium));
-        ModHandler.addShapedRecipe(true, "casing_zpm", MetaBlocks.MACHINE_CASING.getItemVariant(ZPM), "PPP", "PwP",
-                "PPP", 'P', new UnificationEntry(OrePrefix.plate, Materials.NaquadahAlloy));
-        ModHandler.addShapedRecipe(true, "casing_uv", MetaBlocks.MACHINE_CASING.getItemVariant(UV), "PPP", "PwP", "PPP",
-                'P', new UnificationEntry(OrePrefix.plate, Materials.Darmstadtium));
-        ModHandler.addShapedRecipe(true, "casing_uhv", MetaBlocks.MACHINE_CASING.getItemVariant(UHV), "PPP", "PwP",
-                "PPP", 'P', new UnificationEntry(OrePrefix.plate, Materials.Neutronium));
+        if (!ConfigHolder.recipeRemovalConfig.otherStuff.removeTierCasingRecipes) {
+            ModHandler.addShapedRecipe(true, "casing_ulv", MetaBlocks.MACHINE_CASING.getItemVariant(ULV), "PPP", "PwP",
+                    "PPP", 'P', new UnificationEntry(OrePrefix.plate, Materials.WroughtIron));
+            ModHandler.addShapedRecipe(true, "casing_lv", MetaBlocks.MACHINE_CASING.getItemVariant(LV), "PPP", "PwP",
+                    "PPP",
+                    'P', new UnificationEntry(OrePrefix.plate, Materials.Steel));
+            ModHandler.addShapedRecipe(true, "casing_mv", MetaBlocks.MACHINE_CASING.getItemVariant(MV), "PPP", "PwP",
+                    "PPP",
+                    'P', new UnificationEntry(OrePrefix.plate, Materials.Aluminium));
+            ModHandler.addShapedRecipe(true, "casing_hv", MetaBlocks.MACHINE_CASING.getItemVariant(HV), "PPP", "PwP",
+                    "PPP",
+                    'P', new UnificationEntry(OrePrefix.plate, Materials.StainlessSteel));
+            ModHandler.addShapedRecipe(true, "casing_ev", MetaBlocks.MACHINE_CASING.getItemVariant(EV), "PPP", "PwP",
+                    "PPP",
+                    'P', new UnificationEntry(OrePrefix.plate, Materials.Titanium));
+            ModHandler.addShapedRecipe(true, "casing_iv", MetaBlocks.MACHINE_CASING.getItemVariant(IV), "PPP", "PwP",
+                    "PPP",
+                    'P', new UnificationEntry(OrePrefix.plate, Materials.TungstenSteel));
+            ModHandler.addShapedRecipe(true, "casing_luv", MetaBlocks.MACHINE_CASING.getItemVariant(LuV), "PPP", "PwP",
+                    "PPP", 'P', new UnificationEntry(OrePrefix.plate, Materials.RhodiumPlatedPalladium));
+            ModHandler.addShapedRecipe(true, "casing_zpm", MetaBlocks.MACHINE_CASING.getItemVariant(ZPM), "PPP", "PwP",
+                    "PPP", 'P', new UnificationEntry(OrePrefix.plate, Materials.NaquadahAlloy));
+            ModHandler.addShapedRecipe(true, "casing_uv", MetaBlocks.MACHINE_CASING.getItemVariant(UV), "PPP", "PwP",
+                    "PPP",
+                    'P', new UnificationEntry(OrePrefix.plate, Materials.Darmstadtium));
+            ModHandler.addShapedRecipe(true, "casing_uhv", MetaBlocks.MACHINE_CASING.getItemVariant(UHV), "PPP", "PwP",
+                    "PPP", 'P', new UnificationEntry(OrePrefix.plate, Materials.Neutronium));
+        }
 
         // If these recipes are changed, change the values in MaterialInfoLoader.java
         registerMachineRecipe(false, MetaTileEntities.HULL, "PLP", "CHC", 'P', HULL_PLATE, 'L', PLATE, 'C', CABLE, 'H',

--- a/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
@@ -15,6 +15,7 @@ import gregtech.api.unification.material.MarkerMaterials.Color;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.UnificationEntry;
+import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockGlassCasing;
 import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.MetaBlocks;
@@ -463,12 +464,14 @@ public class MiscRecipeLoader {
         CHEMICAL_RECIPES.recipeBuilder().input(dust, GlauconiteSand).input(dust, DarkAsh)
                 .fluidInputs(Water.getFluid(1000)).output(FERTILIZER, 2).duration(200).EUt(VA[LV]).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(FERTILIZER)
-                .output(dust, Calcite)
-                .output(dust, Carbon)
-                .fluidOutputs(Water.getFluid(1000))
-                .duration(100).EUt(VA[LV]).buildAndRegister();
+        if (!ConfigHolder.recipeRemovalConfig.otherStuff.removeElectrolysisRecipes) {
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .input(FERTILIZER)
+                    .output(dust, Calcite)
+                    .output(dust, Carbon)
+                    .fluidOutputs(Water.getFluid(1000))
+                    .duration(100).EUt(VA[LV]).buildAndRegister();
+        }
 
         FORMING_PRESS_RECIPES.recipeBuilder()
                 .inputs(MetaBlocks.TRANSPARENT_CASING.getItemVariant(BlockGlassCasing.CasingType.TEMPERED_GLASS, 2))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/NuclearRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/NuclearRecipes.java
@@ -1,5 +1,7 @@
 package gregtech.loaders.recipe.chemistry;
 
+import gregtech.common.ConfigHolder;
+
 import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
@@ -22,16 +24,18 @@ public class NuclearRecipes {
                 .fluidOutputs(DepletedUraniumHexafluoride.getFluid(900))
                 .buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder().duration(160).EUt(VA[MV])
-                .fluidInputs(EnrichedUraniumHexafluoride.getFluid(1000))
-                .output(dust, Uranium235)
-                .fluidOutputs(Fluorine.getFluid(6000))
-                .buildAndRegister();
+        if (!ConfigHolder.recipeRemovalConfig.otherStuff.removeElectrolysisRecipes) {
+            ELECTROLYZER_RECIPES.recipeBuilder().duration(160).EUt(VA[MV])
+                    .fluidInputs(EnrichedUraniumHexafluoride.getFluid(1000))
+                    .output(dust, Uranium235)
+                    .fluidOutputs(Fluorine.getFluid(6000))
+                    .buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder().duration(160).EUt(VA[MV])
-                .fluidInputs(DepletedUraniumHexafluoride.getFluid(1000))
-                .output(dust, Uranium238)
-                .fluidOutputs(Fluorine.getFluid(6000))
-                .buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder().duration(160).EUt(VA[MV])
+                    .fluidInputs(DepletedUraniumHexafluoride.getFluid(1000))
+                    .output(dust, Uranium238)
+                    .fluidOutputs(Fluorine.getFluid(6000))
+                    .buildAndRegister();
+        }
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/chemistry/PlatGroupMetalsRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/PlatGroupMetalsRecipes.java
@@ -1,5 +1,7 @@
 package gregtech.loaders.recipe.chemistry;
 
+import gregtech.common.ConfigHolder;
+
 import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
@@ -94,11 +96,13 @@ public class PlatGroupMetalsRecipes {
 
         // PLATINUM
 
-        ELECTROLYZER_RECIPES.recipeBuilder().duration(100).EUt(VA[MV])
-                .input(dust, PlatinumRaw, 3)
-                .output(dust, Platinum)
-                .fluidOutputs(Chlorine.getFluid(800))
-                .buildAndRegister();
+        if (!ConfigHolder.recipeRemovalConfig.otherStuff.removeElectrolysisRecipes) {
+            ELECTROLYZER_RECIPES.recipeBuilder().duration(100).EUt(VA[MV])
+                    .input(dust, PlatinumRaw, 3)
+                    .output(dust, Platinum)
+                    .fluidOutputs(Chlorine.getFluid(800))
+                    .buildAndRegister();
+        }
 
         // PALLADIUM
 
@@ -119,12 +123,14 @@ public class PlatGroupMetalsRecipes {
                 .fluidOutputs(Hydrogen.getFluid(3000))
                 .buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder().duration(100).EUt(VA[MV])
-                .fluidInputs(RhodiumSulfate.getFluid(1000))
-                .output(dust, Rhodium, 2)
-                .fluidOutputs(SulfurTrioxide.getFluid(3000))
-                .fluidOutputs(Oxygen.getFluid(3000))
-                .buildAndRegister();
+        if (!ConfigHolder.recipeRemovalConfig.otherStuff.removeElectrolysisRecipes) {
+            ELECTROLYZER_RECIPES.recipeBuilder().duration(100).EUt(VA[MV])
+                    .fluidInputs(RhodiumSulfate.getFluid(1000))
+                    .output(dust, Rhodium, 2)
+                    .fluidOutputs(SulfurTrioxide.getFluid(3000))
+                    .fluidOutputs(Oxygen.getFluid(3000))
+                    .buildAndRegister();
+        }
 
         CHEMICAL_RECIPES.recipeBuilder().duration(200).EUt(VA[MV])
                 .input(dust, RutheniumTetroxide, 5)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -3,6 +3,7 @@ package gregtech.loaders.recipe.chemistry;
 import gregtech.api.GTValues;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
+import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.items.MetaItems;
 
@@ -322,201 +323,203 @@ public class SeparationRecipes {
                 .buildAndRegister();
 
         // Electrolyzer
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(dust, SodiumBisulfate, 7)
-                .fluidOutputs(SodiumPersulfate.getFluid(500))
-                .fluidOutputs(Hydrogen.getFluid(1000))
-                .duration(150).EUt(VA[LV]).buildAndRegister();
+        if (!ConfigHolder.recipeRemovalConfig.otherStuff.removeElectrolysisRecipes) {
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .input(dust, SodiumBisulfate, 7)
+                    .fluidOutputs(SodiumPersulfate.getFluid(500))
+                    .fluidOutputs(Hydrogen.getFluid(1000))
+                    .duration(150).EUt(VA[LV]).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(SaltWater.getFluid(1000))
-                .output(dust, SodiumHydroxide, 3)
-                .fluidOutputs(Chlorine.getFluid(1000))
-                .fluidOutputs(Hydrogen.getFluid(1000))
-                .duration(720).EUt(VA[LV]).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(SaltWater.getFluid(1000))
+                    .output(dust, SodiumHydroxide, 3)
+                    .fluidOutputs(Chlorine.getFluid(1000))
+                    .fluidOutputs(Hydrogen.getFluid(1000))
+                    .duration(720).EUt(VA[LV]).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(dust, Sphalerite, 2)
-                .output(dust, Zinc)
-                .output(dust, Sulfur)
-                .chancedOutput(dust, Gallium, 500, 250)
-                .duration(200).EUt(VA[LV]).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .input(dust, Sphalerite, 2)
+                    .output(dust, Zinc)
+                    .output(dust, Sulfur)
+                    .chancedOutput(dust, Gallium, 500, 250)
+                    .duration(200).EUt(VA[LV]).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Water.getFluid(1000))
-                .fluidOutputs(Hydrogen.getFluid(2000))
-                .fluidOutputs(Oxygen.getFluid(1000))
-                .duration(1500).EUt(VA[LV]).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Water.getFluid(1000))
+                    .fluidOutputs(Hydrogen.getFluid(2000))
+                    .fluidOutputs(Oxygen.getFluid(1000))
+                    .duration(1500).EUt(VA[LV]).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(DistilledWater.getFluid(1000))
-                .fluidOutputs(Hydrogen.getFluid(2000))
-                .fluidOutputs(Oxygen.getFluid(1000))
-                .duration(1500).EUt(VA[LV]).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(DistilledWater.getFluid(1000))
+                    .fluidOutputs(Hydrogen.getFluid(2000))
+                    .fluidOutputs(Oxygen.getFluid(1000))
+                    .duration(1500).EUt(VA[LV]).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .inputs(new ItemStack(Items.DYE, 3))
-                .output(dust, Calcium)
-                .duration(96).EUt(26).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .inputs(new ItemStack(Items.DYE, 3))
+                    .output(dust, Calcium)
+                    .duration(96).EUt(26).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .inputs(new ItemStack(Blocks.SAND, 8))
-                .output(dust, SiliconDioxide)
-                .duration(500).EUt(25).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .inputs(new ItemStack(Blocks.SAND, 8))
+                    .output(dust, SiliconDioxide)
+                    .duration(500).EUt(25).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(dust, Graphite)
-                .output(dust, Carbon, 4)
-                .duration(100).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .input(dust, Graphite)
+                    .output(dust, Carbon, 4)
+                    .duration(100).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(dust, Diamond)
-                .output(dust, Carbon, 64)
-                .duration(768).EUt(VA[LV]).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .input(dust, Diamond)
+                    .output(dust, Carbon, 64)
+                    .duration(768).EUt(VA[LV]).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(dust, Trona, 16)
-                .output(dust, SodaAsh, 6)
-                .output(dust, SodiumBicarbonate, 6)
-                .fluidOutputs(Water.getFluid(2000))
-                .duration(784).EUt(VA[LV] * 2).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .input(dust, Trona, 16)
+                    .output(dust, SodaAsh, 6)
+                    .output(dust, SodiumBicarbonate, 6)
+                    .fluidOutputs(Water.getFluid(2000))
+                    .duration(784).EUt(VA[LV] * 2).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(dust, Bauxite, 15)
-                .output(dust, Aluminium, 6)
-                .output(dust, Rutile)
-                .fluidOutputs(Oxygen.getFluid(9000))
-                .duration(270).EUt(VA[LV] * 2).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .input(dust, Bauxite, 15)
+                    .output(dust, Aluminium, 6)
+                    .output(dust, Rutile)
+                    .fluidOutputs(Oxygen.getFluid(9000))
+                    .duration(270).EUt(VA[LV] * 2).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(dust, Zeolite, 41)
-                .output(dust, Sodium)
-                .output(dust, Calcium, 4)
-                .output(dust, Silicon, 27)
-                .output(dust, Aluminium, 9)
-                .duration(656).EUt(VA[MV]).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .input(dust, Zeolite, 41)
+                    .output(dust, Sodium)
+                    .output(dust, Calcium, 4)
+                    .output(dust, Silicon, 27)
+                    .output(dust, Aluminium, 9)
+                    .duration(656).EUt(VA[MV]).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(dust, Bentonite, 30)
-                .output(dust, Sodium)
-                .output(dust, Magnesium, 6)
-                .output(dust, Silicon, 12)
-                .fluidOutputs(Water.getFluid(5000))
-                .fluidOutputs(Hydrogen.getFluid(6000))
-                .duration(480).EUt(VA[MV]).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .input(dust, Bentonite, 30)
+                    .output(dust, Sodium)
+                    .output(dust, Magnesium, 6)
+                    .output(dust, Silicon, 12)
+                    .fluidOutputs(Water.getFluid(5000))
+                    .fluidOutputs(Hydrogen.getFluid(6000))
+                    .duration(480).EUt(VA[MV]).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(dust, TungsticAcid, 7)
-                .output(dust, Tungsten)
-                .fluidOutputs(Hydrogen.getFluid(2000))
-                .fluidOutputs(Oxygen.getFluid(4000))
-                .duration(210).EUt(960).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .input(dust, TungsticAcid, 7)
+                    .output(dust, Tungsten)
+                    .fluidOutputs(Hydrogen.getFluid(2000))
+                    .fluidOutputs(Oxygen.getFluid(4000))
+                    .duration(210).EUt(960).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(dust, SodiumHydroxide, 3)
-                .output(dust, Sodium)
-                .fluidOutputs(Oxygen.getFluid(1000))
-                .fluidOutputs(Hydrogen.getFluid(1000))
-                .duration(150).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .input(dust, SodiumHydroxide, 3)
+                    .output(dust, Sodium)
+                    .fluidOutputs(Oxygen.getFluid(1000))
+                    .fluidOutputs(Hydrogen.getFluid(1000))
+                    .duration(150).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(dust, Sugar, 3)
-                .output(dust, Carbon)
-                .fluidOutputs(Water.getFluid(1000))
-                .duration(64).EUt(VA[LV]).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .input(dust, Sugar, 3)
+                    .output(dust, Carbon)
+                    .fluidOutputs(Water.getFluid(1000))
+                    .duration(64).EUt(VA[LV]).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(dust, Apatite, 9)
-                .output(dust, Calcium, 5)
-                .output(dust, Phosphorus, 3)
-                .fluidOutputs(Chlorine.getFluid(1000))
-                .duration(288).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .input(dust, Apatite, 9)
+                    .output(dust, Calcium, 5)
+                    .output(dust, Phosphorus, 3)
+                    .fluidOutputs(Chlorine.getFluid(1000))
+                    .duration(288).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Propane.getFluid(1000))
-                .output(dust, Carbon, 3)
-                .fluidOutputs(Hydrogen.getFluid(8000))
-                .duration(176).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Propane.getFluid(1000))
+                    .output(dust, Carbon, 3)
+                    .fluidOutputs(Hydrogen.getFluid(8000))
+                    .duration(176).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Butene.getFluid(1000))
-                .output(dust, Carbon, 4)
-                .fluidOutputs(Hydrogen.getFluid(8000))
-                .duration(192).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Butene.getFluid(1000))
+                    .output(dust, Carbon, 4)
+                    .fluidOutputs(Hydrogen.getFluid(8000))
+                    .duration(192).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Butane.getFluid(1000))
-                .output(dust, Carbon, 4)
-                .fluidOutputs(Hydrogen.getFluid(10000))
-                .duration(224).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Butane.getFluid(1000))
+                    .output(dust, Carbon, 4)
+                    .fluidOutputs(Hydrogen.getFluid(10000))
+                    .duration(224).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Styrene.getFluid(1000))
-                .output(dust, Carbon, 8)
-                .fluidOutputs(Hydrogen.getFluid(8000))
-                .duration(384).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Styrene.getFluid(1000))
+                    .output(dust, Carbon, 8)
+                    .fluidOutputs(Hydrogen.getFluid(8000))
+                    .duration(384).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Butadiene.getFluid(1000))
-                .output(dust, Carbon, 4)
-                .fluidOutputs(Hydrogen.getFluid(6000))
-                .duration(240).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Butadiene.getFluid(1000))
+                    .output(dust, Carbon, 4)
+                    .fluidOutputs(Hydrogen.getFluid(6000))
+                    .duration(240).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Phenol.getFluid(1000))
-                .output(dust, Carbon, 6)
-                .fluidOutputs(Hydrogen.getFluid(6000))
-                .fluidOutputs(Oxygen.getFluid(1000))
-                .duration(312).EUt(90).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Phenol.getFluid(1000))
+                    .output(dust, Carbon, 6)
+                    .fluidOutputs(Hydrogen.getFluid(6000))
+                    .fluidOutputs(Oxygen.getFluid(1000))
+                    .duration(312).EUt(90).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Ethylene.getFluid(1000))
-                .output(dust, Carbon, 2)
-                .fluidOutputs(Hydrogen.getFluid(4000))
-                .duration(96).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Ethylene.getFluid(1000))
+                    .output(dust, Carbon, 2)
+                    .fluidOutputs(Hydrogen.getFluid(4000))
+                    .duration(96).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Benzene.getFluid(1000))
-                .output(dust, Carbon, 6)
-                .fluidOutputs(Hydrogen.getFluid(6000))
-                .duration(288).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Benzene.getFluid(1000))
+                    .output(dust, Carbon, 6)
+                    .fluidOutputs(Hydrogen.getFluid(6000))
+                    .duration(288).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Ethanol.getFluid(1000))
-                .output(dust, Carbon, 2)
-                .fluidOutputs(Hydrogen.getFluid(6000))
-                .fluidOutputs(Oxygen.getFluid(1000))
-                .duration(144).EUt(90).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Ethanol.getFluid(1000))
+                    .output(dust, Carbon, 2)
+                    .fluidOutputs(Hydrogen.getFluid(6000))
+                    .fluidOutputs(Oxygen.getFluid(1000))
+                    .duration(144).EUt(90).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Toluene.getFluid(1000))
-                .output(dust, Carbon, 7)
-                .fluidOutputs(Hydrogen.getFluid(8000))
-                .duration(360).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Toluene.getFluid(1000))
+                    .output(dust, Carbon, 7)
+                    .fluidOutputs(Hydrogen.getFluid(8000))
+                    .duration(360).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Dimethylbenzene.getFluid(1000))
-                .output(dust, Carbon, 8)
-                .fluidOutputs(Hydrogen.getFluid(10000))
-                .duration(432).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Dimethylbenzene.getFluid(1000))
+                    .output(dust, Carbon, 8)
+                    .fluidOutputs(Hydrogen.getFluid(10000))
+                    .duration(432).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Octane.getFluid(1000))
-                .output(dust, Carbon, 8)
-                .fluidOutputs(Hydrogen.getFluid(18000))
-                .duration(624).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Octane.getFluid(1000))
+                    .output(dust, Carbon, 8)
+                    .fluidOutputs(Hydrogen.getFluid(18000))
+                    .duration(624).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Propene.getFluid(1000))
-                .output(dust, Carbon, 3)
-                .fluidOutputs(Hydrogen.getFluid(6000))
-                .duration(144).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Propene.getFluid(1000))
+                    .output(dust, Carbon, 3)
+                    .fluidOutputs(Hydrogen.getFluid(6000))
+                    .duration(144).EUt(60).buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder()
-                .fluidInputs(Ethane.getFluid(1000))
-                .output(dust, Carbon, 2)
-                .fluidOutputs(Hydrogen.getFluid(6000))
-                .duration(128).EUt(60).buildAndRegister();
+            ELECTROLYZER_RECIPES.recipeBuilder()
+                    .fluidInputs(Ethane.getFluid(1000))
+                    .output(dust, Carbon, 2)
+                    .fluidOutputs(Hydrogen.getFluid(6000))
+                    .duration(128).EUt(60).buildAndRegister();
+        }
 
         // Thermal Centrifuge
         THERMAL_CENTRIFUGE_RECIPES.recipeBuilder()

--- a/src/main/java/gregtech/loaders/recipe/handlers/DecompositionRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/DecompositionRecipeHandler.java
@@ -8,6 +8,7 @@ import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.MaterialStack;
+import gregtech.common.ConfigHolder;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
@@ -93,7 +94,8 @@ public class DecompositionRecipeHandler {
 
         // generate builder
         RecipeBuilder<?> builder;
-        if (material.hasFlag(DECOMPOSITION_BY_ELECTROLYZING)) {
+        if (material.hasFlag(DECOMPOSITION_BY_ELECTROLYZING) &&
+                !ConfigHolder.recipeRemovalConfig.otherStuff.removeElectrolysisRecipes) {
             builder = RecipeMaps.ELECTROLYZER_RECIPES.recipeBuilder()
                     .duration(((int) material.getProtons() * totalInputAmount * 2))
                     .EUt(material.getMaterialComponents().size() <= 2 ? VA[LV] : 2 * VA[LV]);

--- a/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
@@ -41,11 +41,17 @@ public class PartsRecipeHandler {
         OrePrefix.plateDense.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processPlateDense);
 
         OrePrefix.turbineBlade.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processTurbine);
-        OrePrefix.rotor.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processRotor);
+        if (!ConfigHolder.processingHandlers.removeRotorRecipes) {
+            OrePrefix.rotor.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processRotor);
+        }
         OrePrefix.bolt.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processBolt);
         OrePrefix.screw.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processScrew);
-        OrePrefix.wireFine.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processFineWire);
-        OrePrefix.foil.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processFoil);
+        if (!ConfigHolder.processingHandlers.removeFineWireRecipes) {
+            OrePrefix.wireFine.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processFineWire);
+        }
+        if (!ConfigHolder.processingHandlers.removeFoilRecipes) {
+            OrePrefix.foil.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processFoil);
+        }
         OrePrefix.lens.addProcessingHandler(PropertyKey.GEM, PartsRecipeHandler::processLens);
 
         OrePrefix.gear.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processGear);

--- a/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
@@ -41,15 +41,15 @@ public class PartsRecipeHandler {
         OrePrefix.plateDense.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processPlateDense);
 
         OrePrefix.turbineBlade.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processTurbine);
-        if (!ConfigHolder.processingHandlers.removeRotorRecipes) {
+        if (!ConfigHolder.recipeRemovalConfig.processingHandlers.removeRotorRecipes) {
             OrePrefix.rotor.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processRotor);
         }
         OrePrefix.bolt.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processBolt);
         OrePrefix.screw.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processScrew);
-        if (!ConfigHolder.processingHandlers.removeFineWireRecipes) {
+        if (!ConfigHolder.recipeRemovalConfig.processingHandlers.removeFineWireRecipes) {
             OrePrefix.wireFine.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processFineWire);
         }
-        if (!ConfigHolder.processingHandlers.removeFoilRecipes) {
+        if (!ConfigHolder.recipeRemovalConfig.processingHandlers.removeFoilRecipes) {
             OrePrefix.foil.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processFoil);
         }
         OrePrefix.lens.addProcessingHandler(PropertyKey.GEM, PartsRecipeHandler::processLens);

--- a/src/main/java/gregtech/loaders/recipe/handlers/RecipeHandlerList.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/RecipeHandlerList.java
@@ -9,7 +9,7 @@ public class RecipeHandlerList {
         OreRecipeHandler.register();
         PartsRecipeHandler.register();
         WireRecipeHandler.register();
-        if (!ConfigHolder.processingHandlers.removeWireRecipes) WireCombiningHandler.register();
+        if (!ConfigHolder.recipeRemovalConfig.processingHandlers.removeWireRecipes) WireCombiningHandler.register();
         PipeRecipeHandler.register();
         ToolRecipeHandler.register();
         PolarizingRecipeHandler.register();

--- a/src/main/java/gregtech/loaders/recipe/handlers/RecipeHandlerList.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/RecipeHandlerList.java
@@ -1,5 +1,7 @@
 package gregtech.loaders.recipe.handlers;
 
+import gregtech.common.ConfigHolder;
+
 public class RecipeHandlerList {
 
     public static void register() {
@@ -7,7 +9,7 @@ public class RecipeHandlerList {
         OreRecipeHandler.register();
         PartsRecipeHandler.register();
         WireRecipeHandler.register();
-        WireCombiningHandler.register();
+        if (!ConfigHolder.processingHandlers.removeWireRecipes) WireCombiningHandler.register();
         PipeRecipeHandler.register();
         ToolRecipeHandler.register();
         PolarizingRecipeHandler.register();

--- a/src/main/java/gregtech/loaders/recipe/handlers/WireRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/WireRecipeHandler.java
@@ -52,7 +52,7 @@ public class WireRecipeHandler {
 
     public static void register() {
         // Generate 1x Wire creation recipes (Wiremill, Extruder, Wire Cutters)
-        if (!ConfigHolder.processingHandlers.removeWireRecipes) {
+        if (!ConfigHolder.recipeRemovalConfig.processingHandlers.removeWireRecipes) {
             wireGtSingle.addProcessingHandler(PropertyKey.WIRE, WireRecipeHandler::processWireSingle);
         }
 

--- a/src/main/java/gregtech/loaders/recipe/handlers/WireRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/WireRecipeHandler.java
@@ -10,6 +10,7 @@ import gregtech.api.unification.material.properties.WireProperties;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.util.GTUtility;
+import gregtech.common.ConfigHolder;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -51,7 +52,9 @@ public class WireRecipeHandler {
 
     public static void register() {
         // Generate 1x Wire creation recipes (Wiremill, Extruder, Wire Cutters)
-        wireGtSingle.addProcessingHandler(PropertyKey.WIRE, WireRecipeHandler::processWireSingle);
+        if (!ConfigHolder.processingHandlers.removeWireRecipes) {
+            wireGtSingle.addProcessingHandler(PropertyKey.WIRE, WireRecipeHandler::processWireSingle);
+        }
 
         // Generate Cable Covering Recipes
         wireGtSingle.addProcessingHandler(PropertyKey.WIRE, WireRecipeHandler::generateCableCovering);
@@ -111,6 +114,7 @@ public class WireRecipeHandler {
         int insulationAmount = INSULATION_AMOUNT.get(cablePrefix);
 
         // Generate hand-crafting recipes for ULV and LV cables
+
         if (voltageTier <= GTValues.LV) {
             generateManualRecipe(wirePrefix, material, cablePrefix, cableAmount);
         }


### PR DESCRIPTION
To avoid use of reflection or other shenanigans to remove recipes for addons.
- added config to disable several oreprefixes processing handlers
- added config to remove tin-using circuit recipes
- added config to remove components recipes
